### PR TITLE
feat: add range option for sub function

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,25 @@ require("rip-substitute").setup {
 ## Usage
 
 ```lua
-require("rip-substitute").sub()
+require("rip-substitute").sub(opts)
 ```
 
+Or use the cmdline `:RipSub`. It also available with ranges - `:,$RipSub`.
+
+The possible parameters of `opts`:
+- range: (optional) Map defining the range:
+	* startLine: (number) the start line of substitution
+	* endLine: (number) the end line of substitution
+
+Behaviors:
 - Normal mode: prefills the cursorword.
 - Visual mode: prefills the first line of the selection.
 - Visual *line* mode: replacements are only applied to the selected lines
   (the selection is used as range).
+
+> [!NOTE]
+> Make sure you only use the range option or Visual *line* mode, not both. If
+> you did, the default behavior (i.e. Normal mode) will be used.
 
 ## Advanced
 **`autoBraceSimpleCaptureGroups`**  

--- a/lua/rip-substitute/opts.lua
+++ b/lua/rip-substitute/opts.lua
@@ -1,0 +1,68 @@
+local M = {}
+local notify = require("rip-substitute.utils").notify
+--------------------------------------------------------------------------------
+
+---@class ripSubstituteOpts
+local userOpts = {
+	range = {
+		startLine = 0,
+		endLine = 0,
+	},
+}
+
+---@param opts? ripSubstituteOpts
+---@param mode string
+---@return CmdRange|false
+function M.getRange(opts, mode)
+	local ABORT_MSG = "Aborting selection and using default substitution."
+
+	if opts and opts.range and mode == "V" then
+		notify(
+			"Conflict of two ranges: of defined in opts and of VISUAL mode.\n\n" ..
+			ABORT_MSG,
+			"warn")
+		return false
+	end
+
+	if opts and opts.range then
+		local range = opts.range
+
+		if not range.startLine then
+			notify(
+				"Invalid range from defined in opts: the start line is not defined.\n\n" ..
+				ABORT_MSG,
+				"warn")
+			return false
+		end
+
+		if not range.endLine then
+			notify(
+				"Invalid range from defined in opts: the end line is not defined.\n\n" ..
+				ABORT_MSG,
+				"warn")
+			return false
+		end
+
+		if range.startLine > range.endLine then
+			notify(
+				"Invalid range from defined in opts: the start is after of the end.\n\n" ..
+				ABORT_MSG,
+				"warn")
+			return false
+		end
+
+		return { start = range.startLine, end_ = range.endLine }
+	end
+
+	if mode == "V" then
+		vim.cmd.normal { "V", bang = true } -- leave visual mode, so marks are set
+		local startLn = vim.api.nvim_buf_get_mark(0, "<")[1]
+		local endLn = vim.api.nvim_buf_get_mark(0, ">")[1]
+		return { start = startLn, end_ = endLn }
+	end
+
+	return false
+end
+
+--------------------------------------------------------------------------------
+return M


### PR DESCRIPTION
# Main concept

Adds the range option for function `sub()`, which can be used for ranging lines instead of using Visual *line* mode for most cases.

## Motivation

It's very helpful for substituting the variables in range from current line and below. Some programming languages allows reuse the variable with the same name for another type, so the LSP can't substitute correctly in this case. And it can work in opposite case - when I only want to change the variable name in range from specific line above to current.

## Implementation

I added the optional table argument for function `sub()` named `opts`. Also added the `opts.lua` module. It can be used easily for extending the function by new features.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
