### PR TITLE
feat: Add prefill via command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ To prefill the current selection, you therefore need to use the lua function.)
 :.,$ RipSubstitute
 ```
 
+You can also pass the search value through the command.
+
+```vim
+:RipSubstitute foobar
+```
+
 ## Advanced
 **`autoBraceSimpleCaptureGroups`**  
 A *gotcha* of `ripgrep`'s regex syntax is that it treats `$1a` as the named

--- a/plugin/rip-substitute-user-command.lua
+++ b/plugin/rip-substitute-user-command.lua
@@ -1,5 +1,5 @@
 vim.api.nvim_create_user_command(
 	"RipSubstitute",
 	function(args) require("rip-substitute").sub(args) end,
-	{ desc = "nvim-rip-substitute", range = true }
+	{ desc = "nvim-rip-substitute", range = true, nargs = "?" }
 )


### PR DESCRIPTION
Hi!
Nice plugin, thank you!

I would like to offer a concept of passing search value through the command.
I am using this workflow in my config now with :s///. And it would be nice to have the same with your plugin.

It looks like that:

[![Watch the video]](https://github.com/chrisgrieser/nvim-rip-substitute/assets/125148819/539e8afa-1de3-4b8f-8858-dfd51b26b53c)

## Checklist
- [X] Used only camelCase variable names.
- [X] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
