### PR TITLE
fix: fix floating window position

### DIFF
--- a/lua/rip-substitute/popup-win.lua
+++ b/lua/rip-substitute/popup-win.lua
@@ -257,7 +257,7 @@ function M.openSubstitutionPopup()
 	local popupZindex = 49 -- below nvim-notify (50), above scrollbars (satellite uses 40)
 	state.popupWinNr = vim.api.nvim_open_win(state.popupBufNr, true, {
 		relative = "win",
-		anchor = "SE",
+		anchor = config.popupWin.position == "top" and "NE" or "SE",
 		row = config.popupWin.position == "top" and 0 or vim.api.nvim_win_get_height(0),
 		col = vim.api.nvim_win_get_width(0),
 		width = minWidth,

--- a/lua/rip-substitute/popup-win.lua
+++ b/lua/rip-substitute/popup-win.lua
@@ -257,8 +257,9 @@ function M.openSubstitutionPopup()
 	local popupZindex = 49 -- below nvim-notify (50), above scrollbars (satellite uses 40)
 	state.popupWinNr = vim.api.nvim_open_win(state.popupBufNr, true, {
 		relative = "win",
+		anchor = "SE",
 		row = config.popupWin.position == "top" and 0 or vim.api.nvim_win_get_height(0),
-		col = vim.api.nvim_win_get_width(0) - minWidth,
+		col = vim.api.nvim_win_get_width(0),
 		width = minWidth,
 		height = 2,
 


### PR DESCRIPTION
This PR fixes problems with the positioning of the floating window, especially when using the default bottom position where it would overlap the status line and command line, or in the case of a vertical split, it would be shown below the split line.

Before:

Overlapping command line (causing rendering errors in neovide)

![image](https://github.com/user-attachments/assets/481a8aaf-bb0a-4df4-85ac-05cf1d031f3e)

Shown below horizontal split line:

![image](https://github.com/user-attachments/assets/79cd8549-de92-43a4-b597-4be6f533d419)

Shown overlapping command line and vertical split line

![image](https://github.com/user-attachments/assets/b986715c-8248-40c9-9799-e183f6ed2e87)

After this PR:

Shown above command line

![image](https://github.com/user-attachments/assets/74712db9-075d-40bf-bd3d-898701bdd36d)

Shown above horizontal split line

![image](https://github.com/user-attachments/assets/38b11b86-0e8b-459c-aae0-1e59a20b8ada)

Shown above command line and to the left of vertfical split line

![image](https://github.com/user-attachments/assets/bbe19d31-1871-4408-a6a2-d00256b5048f)


## Checklist
- [x] Used only camelCase variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
