### PR TITLE
feat: support allowing regex off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ require("rip-substitute").setup {
 		},
 	},
 	regexOptions = {
+		-- Start with fixed strings on by default
+		literalByDefault = false,
 		-- pcre2 enables lookarounds and backreferences, but performs slower
 		pcre2 = true,
 		---@type "case-sensitive"|"ignore-case"|"smart-case"

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ require("rip-substitute").setup {
 		},
 	},
 	regexOptions = {
-		-- Start with fixed strings on by default
-		literalByDefault = false,
+		startWithFixedStringsOn = false,
 		-- pcre2 enables lookarounds and backreferences, but performs slower
 		pcre2 = true,
 		---@type "case-sensitive"|"ignore-case"|"smart-case"

--- a/lua/rip-substitute/config.lua
+++ b/lua/rip-substitute/config.lua
@@ -36,6 +36,8 @@ local defaultConfig = {
 		},
 	},
 	regexOptions = {
+		-- Start with regex off
+		literalByDefault = false,
 		-- pcre2 enables lookarounds and backreferences, but performs slower
 		pcre2 = true,
 		---@type "case-sensitive"|"ignore-case"|"smart-case"

--- a/lua/rip-substitute/config.lua
+++ b/lua/rip-substitute/config.lua
@@ -36,8 +36,7 @@ local defaultConfig = {
 		},
 	},
 	regexOptions = {
-		-- Start with regex off
-		literalByDefault = false,
+		startWithFixedStringsOn = false,
 		-- pcre2 enables lookarounds and backreferences, but performs slower
 		pcre2 = true,
 		---@type "case-sensitive"|"ignore-case"|"smart-case"
@@ -58,6 +57,10 @@ M.config = defaultConfig
 function M.setup(userConfig)
 	M.config = vim.tbl_deep_extend("force", M.config, userConfig or {})
 	local notify = require("rip-substitute.utils").notify
+
+	if M.config.regexOptions.startWithFixedStringsOn then
+		require("rip-substitute.state").state.useFixedStrings = true
+	end
 
 	-- VALIDATE `rg` installations not built with `pcre2`, see #3
 	if M.config.regexOptions.pcre2 then

--- a/lua/rip-substitute/init.lua
+++ b/lua/rip-substitute/init.lua
@@ -16,12 +16,7 @@ local M = {}
 --------------------------------------------------------------------------------
 
 ---@param userConfig? ripSubstituteConfig
-function M.setup(userConfig)
-	require("rip-substitute.config").setup(userConfig)
-	if userConfig.regexOptions.literalByDefault then
-		require("rip-substitute.state").state.useFixedStrings = true
-	end
-end
+function M.setup(userConfig) require("rip-substitute.config").setup(userConfig) end
 
 function M.rememberCursorWord()
 	local state = require("rip-substitute.state").state

--- a/lua/rip-substitute/init.lua
+++ b/lua/rip-substitute/init.lua
@@ -16,7 +16,12 @@ local M = {}
 --------------------------------------------------------------------------------
 
 ---@param userConfig? ripSubstituteConfig
-function M.setup(userConfig) require("rip-substitute.config").setup(userConfig) end
+function M.setup(userConfig)
+	require("rip-substitute.config").setup(userConfig)
+	if userConfig.regexOptions.literalByDefault then
+		require("rip-substitute.state").state.useFixedStrings = true
+	end
+end
 
 function M.rememberCursorWord()
 	local state = require("rip-substitute.state").state

--- a/lua/rip-substitute/run-parameters.lua
+++ b/lua/rip-substitute/run-parameters.lua
@@ -22,7 +22,7 @@ function M.setParameters(exCmdArgs)
 		vim.cmd.normal { '"zy', bang = true }
 		searchPrefill = vim.fn.getreg("z"):gsub("[\n\r].*", "") -- only first line
 	end
-	if not exCmdHasSearchPrefill and not config.regexOptions.literalByDefault then
+	if not exCmdHasSearchPrefill and not config.regexOptions.startWithFixedStringsOn then
 		-- escape special chars only when not using prefill and not literal mode
 		-- by default
 		searchPrefill = searchPrefill:gsub("[.(){}[%]*+?^$]", [[\%1]])

--- a/lua/rip-substitute/run-parameters.lua
+++ b/lua/rip-substitute/run-parameters.lua
@@ -22,8 +22,9 @@ function M.setParameters(exCmdArgs)
 		vim.cmd.normal { '"zy', bang = true }
 		searchPrefill = vim.fn.getreg("z"):gsub("[\n\r].*", "") -- only first line
 	end
-	if not exCmdHasSearchPrefill then
-		-- escape special chars only when not using prefill
+	if not exCmdHasSearchPrefill and not config.regexOptions.literalByDefault then
+		-- escape special chars only when not using prefill and not literal mode
+		-- by default
 		searchPrefill = searchPrefill:gsub("[.(){}[%]*+?^$]", [[\%1]])
 	end
 


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

I prefer to use plain text like IntelliJ. This setting allows this plugin to work like IntelliJ.

This will open the popup with fixed strings enabled if set to true in the config. It will also prevent escaping of regex meta characters.