### PR TITLE
feat: `<C-c>c` to toggle case sensitivity + update buffer settings display

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ require("rip-substitute").setup {
 		prevSubst = "<Up>",
 		nextSubst = "<Down>",
 		toggleFixedStrings = "<C-f>",
-	    toggleCaseSensitive = "<C-c>c",
+	  toggleCaseSensitive = "<C-c>",
 		openAtRegex101 = "R",
 	},
 	incrementalPreview = {

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ require("rip-substitute").setup {
 		prevSubst = "<Up>",
 		nextSubst = "<Down>",
 		toggleFixedStrings = "<C-f>",
+	    toggleCaseSensitive = "<C-c>c",
 		openAtRegex101 = "R",
 	},
 	incrementalPreview = {

--- a/lua/rip-substitute/config.lua
+++ b/lua/rip-substitute/config.lua
@@ -26,6 +26,7 @@ local defaultConfig = {
 		prevSubst = "<Up>",
 		nextSubst = "<Down>",
 		toggleFixedStrings = "<C-f>",
+		toggleCaseSensitive = "<C-c>c",
 		openAtRegex101 = "R",
 	},
 	incrementalPreview = {

--- a/lua/rip-substitute/config.lua
+++ b/lua/rip-substitute/config.lua
@@ -26,7 +26,7 @@ local defaultConfig = {
 		prevSubst = "<Up>",
 		nextSubst = "<Down>",
 		toggleFixedStrings = "<C-f>",
-		toggleCaseSensitive = "<C-c>c",
+		toggleCaseSensitive = "<C-c>",
 		openAtRegex101 = "R",
 	},
 	incrementalPreview = {

--- a/lua/rip-substitute/popup-win.lua
+++ b/lua/rip-substitute/popup-win.lua
@@ -215,9 +215,18 @@ local function setPopupTitle()
 	if state.range then
 		title = "Range: " .. state.range.start
 		if state.range.start ~= state.range.end_ then title = title .. " – " .. state.range.end_ end
-		if state.useFixedStrings then title = title .. " [Fixed Strings]" end
-	elseif state.useFixedStrings then
-		title = "[Fixed Strings]"
+	end
+
+	if state.useFixedStrings then
+		title = title .. " 󰑑 󰅙"
+	else
+		title = title .. " 󰑑 󰗠"
+	end
+
+	if state.caseSensitive then
+		title = title .. " Aa 󰗠"
+	else
+		title = title .. " Aa 󰅙"
 	end
 
 	vim.api.nvim_win_set_config(state.popupWinNr, { title = " " .. title .. " " })
@@ -276,6 +285,14 @@ local function createKeymaps()
 		updateMatchCount()
 		setPopupTitle()
 	end, opts)
+
+	-- toggle case sensitive
+	vim.keymap.set({ "n", "x" }, keymaps.toggleCaseSensitive, function()
+		state.caseSensitive = not state.caseSensitive
+		require("rip-substitute.rg-operations").incrementalPreviewAndMatchCount()
+		updateMatchCount()
+		setPopupTitle()
+	end, opts)
 end
 
 --------------------------------------------------------------------------------
@@ -297,7 +314,12 @@ function M.openSubstitutionPopup()
 	local m = config.keymaps
 	local keymapHint = #state.popupHistory == 0
 			and ("%s confirm  %s abort"):format(m.confirm, m.abort)
-		or ("%s/%s history  %s literal"):format(m.prevSubst, m.nextSubst, m.toggleFixedStrings)
+		or ("%s/%s history  %s literal %s case sensitive"):format(
+			m.prevSubst,
+			m.nextSubst,
+			m.toggleFixedStrings,
+			m.toggleCaseSensitive
+		)
 	keymapHint = keymapHint -- using only utf symbols, so they work w/o nerd fonts
 		:gsub("<[Cc][Rr]>", "↩")
 		:gsub("<[dD]own>", "↓")

--- a/lua/rip-substitute/popup-win.lua
+++ b/lua/rip-substitute/popup-win.lua
@@ -217,17 +217,8 @@ local function setPopupTitle()
 		if state.range.start ~= state.range.end_ then title = title .. " – " .. state.range.end_ end
 	end
 
-	if state.useFixedStrings then
-		title = title .. " 󰑑 󰅙"
-	else
-		title = title .. " 󰑑 󰗠"
-	end
-
-	if state.caseSensitive then
-		title = title .. " Aa 󰗠"
-	else
-		title = title .. " Aa 󰅙"
-	end
+	title = state.useFixedStrings and title .. " -F" or title
+	title = state.useCaseSensitive and title .. " -s" or title .. " -i"
 
 	vim.api.nvim_win_set_config(state.popupWinNr, { title = " " .. title .. " " })
 end
@@ -288,7 +279,7 @@ local function createKeymaps()
 
 	-- toggle case sensitive
 	vim.keymap.set({ "n", "x" }, keymaps.toggleCaseSensitive, function()
-		state.caseSensitive = not state.caseSensitive
+		state.useCaseSensitive = not state.useCaseSensitive
 		require("rip-substitute.rg-operations").incrementalPreviewAndMatchCount()
 		updateMatchCount()
 		setPopupTitle()
@@ -314,12 +305,7 @@ function M.openSubstitutionPopup()
 	local m = config.keymaps
 	local keymapHint = #state.popupHistory == 0
 			and ("%s confirm  %s abort"):format(m.confirm, m.abort)
-		or ("%s/%s history  %s literal %s case sensitive"):format(
-			m.prevSubst,
-			m.nextSubst,
-			m.toggleFixedStrings,
-			m.toggleCaseSensitive
-		)
+		or ("%s/%s history %s literal"):format(m.prevSubst, m.nextSubst, m.toggleFixedStrings)
 	keymapHint = keymapHint -- using only utf symbols, so they work w/o nerd fonts
 		:gsub("<[Cc][Rr]>", "↩")
 		:gsub("<[dD]own>", "↓")

--- a/lua/rip-substitute/rg-operations.lua
+++ b/lua/rip-substitute/rg-operations.lua
@@ -17,7 +17,7 @@ local function runRipgrep(rgArgs)
 		config.regexOptions.pcre2 and "--pcre2" or "--no-pcre2",
 		"--" .. config.regexOptions.casing,
 		state.useFixedStrings and "--fixed-strings" or "--no-fixed-strings",
-		state.caseSensitive and "--case-sensitive" or "--ignore-case",
+		state.useCaseSensitive and "--case-sensitive" or "--ignore-case",
 		windowsEol and "--crlf" or "--no-crlf", -- see #17
 	}
 	vim.list_extend(args, rgArgs)

--- a/lua/rip-substitute/rg-operations.lua
+++ b/lua/rip-substitute/rg-operations.lua
@@ -17,6 +17,7 @@ local function runRipgrep(rgArgs)
 		config.regexOptions.pcre2 and "--pcre2" or "--no-pcre2",
 		"--" .. config.regexOptions.casing,
 		state.useFixedStrings and "--fixed-strings" or "--no-fixed-strings",
+		state.caseSensitive and "--case-sensitive" or "--ignore-case",
 		windowsEol and "--crlf" or "--no-crlf", -- see #17
 	}
 	vim.list_extend(args, rgArgs)

--- a/lua/rip-substitute/state.lua
+++ b/lua/rip-substitute/state.lua
@@ -19,10 +19,12 @@ local M = {}
 ---@field searchPrefill? string
 ---@field rememberedPrefill? string
 ---@field useFixedStrings? boolean
+---@field caseSensitive? boolean
 M.state = {
 	popupHistory = {},
 	matchCount = 0,
 	useFixedStrings = false,
+	caseSensitive = false,
 }
 
 ---@type string

--- a/lua/rip-substitute/state.lua
+++ b/lua/rip-substitute/state.lua
@@ -19,12 +19,12 @@ local M = {}
 ---@field searchPrefill? string
 ---@field rememberedPrefill? string
 ---@field useFixedStrings? boolean
----@field caseSensitive? boolean
+---@field useCaseSensitive? boolean
 M.state = {
 	popupHistory = {},
 	matchCount = 0,
 	useFixedStrings = false,
-	caseSensitive = false,
+	useCaseSensitive = false,
 }
 
 ---@type string


### PR DESCRIPTION
(cherry picked from commit 8f5939116616bcf63f74595853de90ea9f06650f)

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

In terms of the bit at the bottom of the buffer that indicated fixed strings, Ive replaced it with a regex icon in line with VSCode and IntelliJ. this is because when I added the case sensitivity it would look crowded. Ive made them both display a nerd font icon instead.

As for the main feature it just toggles case sensitivity with a similar mechanism to the fixed strings code.