### PR TITLE
fix: always provide no-crlf to stop ^M from displaying after match

### DIFF
--- a/lua/rip-substitute/rg-operations.lua
+++ b/lua/rip-substitute/rg-operations.lua
@@ -12,7 +12,6 @@ local function runRipgrep(rgArgs)
 	local config = require("rip-substitute.config").config
 	local targetBufCache = require("rip-substitute.state").targetBufCache
 	local state = require("rip-substitute.state").state
-	local windowsEol = vim.bo[state.targetBuf].fileformat == "dos"
 
 	local args = {
 		"rg",
@@ -20,7 +19,7 @@ local function runRipgrep(rgArgs)
 		config.regexOptions.pcre2 and "--pcre2" or "--no-pcre2",
 		state.useFixedStrings and "--fixed-strings" or "--no-fixed-strings",
 		state.useIgnoreCase and "--ignore-case" or "--case-sensitive",
-		windowsEol and "--crlf" or "--no-crlf", -- see #17
+		"--no-crlf", -- see #17
 	}
 	vim.list_extend(args, rgArgs)
 


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).

I opened this bug: #17 - but I've still had issues with ^M being displayed directly after the match. I've experimented with always providing --no-crlf and that seems to actually fix the issue.

This happens when editing a dos fileformat file. 


The issue:
![image](https://github.com/user-attachments/assets/3b4f5dfa-ea89-4c8f-920b-5ab6c7df95ac)

![image](https://github.com/user-attachments/assets/f385de56-cf0d-43dc-8bc6-577225d091fc)

