### PR TITLE
fix(typo): vim.b.completions -> vim.b.completion for `disableCompletions`

### DIFF
--- a/lua/rip-substitute/popup-win.lua
+++ b/lua/rip-substitute/popup-win.lua
@@ -326,8 +326,8 @@ function M.openSubstitutionPopup()
 	vim.bo[bufnr].filetype = "rip-substitute"
 	state.popupBufNr = bufnr
 
-	-- disable blink.cmp completions https://cmp.saghen.dev/recipes.html#disable-per-filetypebuffer
-	if config.popupWin.disableCompletions then vim.b[bufnr].completions = false end
+	-- disable blink.cmp completions https://main.cmp.saghen.dev/recipes.html#disable-per-filetype-buffer
+	if config.popupWin.disableCompletions then vim.b[bufnr].completion = false end
 
 	-- FOOTER & WIDTH
 	local maps = require("rip-substitute.config").config.keymaps


### PR DESCRIPTION
## What problem does this PR solve?

Fix `opts.popupWin.disableCompletions`.

## How does the PR solve it?

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
